### PR TITLE
[Qt] Debug window: replace "Build date" with "Datadir"

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -228,11 +228,6 @@ QString ClientModel::formatFullVersion() const
     return QString::fromStdString(FormatFullVersion());
 }
 
-QString ClientModel::formatBuildDate() const
-{
-    return QString::fromStdString(CLIENT_DATE);
-}
-
 bool ClientModel::isReleaseVersion() const
 {
     return CLIENT_VERSION_IS_RELEASE;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -248,6 +248,11 @@ QString ClientModel::formatClientStartupTime() const
     return QDateTime::fromTime_t(nClientStartupTime).toString();
 }
 
+QString ClientModel::dataDir() const
+{
+    return QString::fromStdString(GetDataDir().string());
+}
+
 void ClientModel::updateBanlist()
 {
     banTableModel->refresh();

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -75,6 +75,7 @@ public:
     bool isReleaseVersion() const;
     QString clientName() const;
     QString formatClientStartupTime() const;
+    QString dataDir() const;
 
 private:
     OptionsModel* optionsModel;

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -71,7 +71,6 @@ public:
     QString getStatusBarWarnings() const;
 
     QString formatFullVersion() const;
-    QString formatBuildDate() const;
     bool isReleaseVersion() const;
     QString clientName() const;
     QString formatClientStartupTime() const;

--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -141,12 +141,12 @@
        <item row="5" column="0">
         <widget class="QLabel" name="buildDateLabel">
          <property name="text">
-          <string>Build date</string>
+          <string>Datadir</string>
          </property>
         </widget>
        </item>
        <item row="5" column="1">
-        <widget class="QLabel" name="buildDate">
+        <widget class="QLabel" name="dataDir">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -155,6 +155,9 @@
          </property>
          <property name="textFormat">
           <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -428,7 +428,7 @@ void RPCConsole::setClientModel(ClientModel* model)
         // Provide initial values
         ui->clientVersion->setText(model->formatFullVersion());
         ui->clientName->setText(model->clientName());
-        ui->buildDate->setText(model->formatBuildDate());
+        ui->dataDir->setText(model->dataDir());
         ui->startupTime->setText(model->formatClientStartupTime());
         ui->networkName->setText(QString::fromStdString(Params().NetworkIDString()));
 


### PR DESCRIPTION
The build date only makes sense for custom/self-compiled Wagerr versions because we are using static build-dates for our deterministic release builds.

Having a quick option to get the current datadir is much more valuable for debug purposes.

This also relates to some build system overhauls I'm doing, but just want to get this out of the way first!

**Screenshot**

![datadir](https://user-images.githubusercontent.com/36657478/37135309-6ff73fe6-22e8-11e8-9dd8-8cbad6d14765.png)
