### PR TITLE
Count masternode coins once instead of twice

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1198,13 +1198,8 @@ CAmount CWalletTx::GetLockedCredit() const
         // Skip spent coins
         if (pwallet->IsSpent(hashTx, i)) continue;
 
-        // Add locked coins
-        if (pwallet->IsLockedCoin(hashTx, i)) {
-            nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
-        }
-
-        // Add masternode collaterals which are handled likc locked coins
-        if (fMasterNode && vout[i].nValue == 25000 * COIN) {
+        // Add locked coins and masternode collateral (which are handled like locked coins)
+        if (pwallet->IsLockedCoin(hashTx, i) || (fMasterNode && vout[i].nValue == 25000 * COIN)) {
             nCredit += pwallet->GetCredit(txout, ISMINE_SPENDABLE);
         }
 


### PR DESCRIPTION
Fix GetLockedCredit() to count masternode coins once for the locked coins balance 