### PR TITLE
[Qt] Clean up Multisend Dialog UI

### DIFF
--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -98,7 +98,6 @@ void MultiSendDialog::on_viewButton_clicked()
     ui->message->setProperty("status", "ok");
     ui->message->style()->polish(ui->message);
     ui->message->setText(strStatus + QString(strMultiSendPrint.c_str()));
-    return;
 }
 
 void MultiSendDialog::on_addButton_clicked()
@@ -164,7 +163,6 @@ void MultiSendDialog::on_addButton_clicked()
         return;
     }
     ui->message->setText(tr("MultiSend Vector") + "\n" + QString(strMultiSendPrint.c_str()));
-    return;
 }
 
 void MultiSendDialog::on_deleteButton_clicked()
@@ -190,8 +188,6 @@ void MultiSendDialog::on_deleteButton_clicked()
         ui->message->setText(tr("Could not locate address"));
 
     updateCheckBoxes();
-
-    return;
 }
 
 void MultiSendDialog::on_activateButton_clicked()
@@ -215,7 +211,6 @@ void MultiSendDialog::on_activateButton_clicked()
     ui->message->setProperty("status", "ok");
     ui->message->style()->polish(ui->message);
     ui->message->setText(strRet);
-    return;
 }
 
 void MultiSendDialog::on_disableButton_clicked()
@@ -232,5 +227,4 @@ void MultiSendDialog::on_disableButton_clicked()
     ui->message->setProperty("status", "");
     ui->message->style()->polish(ui->message);
     ui->message->setText(strRet);
-    return;
 }

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -12,7 +12,6 @@
 #include "walletmodel.h"
 #include <QLineEdit>
 #include <QMessageBox>
-#include <boost/lexical_cast.hpp>
 
 
 MultiSendDialog::MultiSendDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
@@ -92,7 +91,7 @@ void MultiSendDialog::on_viewButton_clicked()
         }
         strMultiSendPrint += pMultiSend.first.c_str();
         strMultiSendPrint += " - ";
-        strMultiSendPrint += boost::lexical_cast<string>(pMultiSend.second);
+        strMultiSendPrint += std::to_string(pMultiSend.second);
         strMultiSendPrint += "% \n";
     }
     ui->message->setProperty("status", "ok");
@@ -141,7 +140,7 @@ void MultiSendDialog::on_addButton_clicked()
         pMultiSend = pwalletMain->vMultiSend[i];
         strMultiSendPrint += pMultiSend.first.c_str();
         strMultiSendPrint += " - ";
-        strMultiSendPrint += boost::lexical_cast<string>(pMultiSend.second);
+        strMultiSendPrint += std::to_string(pMultiSend.second);
         strMultiSendPrint += "% \n";
     }
 

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -14,8 +14,6 @@
 #include <QMessageBox>
 #include <boost/lexical_cast.hpp>
 
-using namespace std;
-using namespace boost;
 
 MultiSendDialog::MultiSendDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                                     ui(new Ui::MultiSendDialog),

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -70,16 +70,17 @@ void MultiSendDialog::on_addressBookButton_clicked()
 void MultiSendDialog::on_viewButton_clicked()
 {
     std::pair<std::string, int> pMultiSend;
-    std::string strMultiSendPrint = "";
+    std::string strMultiSendPrint;
+    QString strStatus;
     if (pwalletMain->isMultiSendEnabled()) {
         if (pwalletMain->fMultiSendStake && pwalletMain->fMultiSendMasternodeReward)
-            strMultiSendPrint += "MultiSend Active for Stakes and Masternode Rewards\n";
+            strStatus += tr("MultiSend Active for Stakes and Masternode Rewards") + "\n";
         else if (pwalletMain->fMultiSendStake)
-            strMultiSendPrint += "MultiSend Active for Stakes\n";
+            strStatus += tr("MultiSend Active for Stakes") + "\n";
         else if (pwalletMain->fMultiSendMasternodeReward)
-            strMultiSendPrint += "MultiSend Active for Masternode Rewards\n";
+            strStatus += tr("MultiSend Active for Masternode Rewards") + "\n";
     } else
-        strMultiSendPrint += "MultiSend Not Active\n";
+        strStatus += tr("MultiSend Not Active") + "\n";
 
     for (int i = 0; i < (int)pwalletMain->vMultiSend.size(); i++) {
         pMultiSend = pwalletMain->vMultiSend[i];
@@ -92,11 +93,11 @@ void MultiSendDialog::on_viewButton_clicked()
         strMultiSendPrint += pMultiSend.first.c_str();
         strMultiSendPrint += " - ";
         strMultiSendPrint += std::to_string(pMultiSend.second);
-        strMultiSendPrint += "% \n";
+        strMultiSendPrint += "%\n";
     }
     ui->message->setProperty("status", "ok");
     ui->message->style()->polish(ui->message);
-    ui->message->setText(QString(strMultiSendPrint.c_str()));
+    ui->message->setText(strStatus + QString(strMultiSendPrint.c_str()));
     return;
 }
 
@@ -107,7 +108,7 @@ void MultiSendDialog::on_addButton_clicked()
     if (!CBitcoinAddress(strAddress).IsValid()) {
         ui->message->setProperty("status", "error");
         ui->message->style()->polish(ui->message);
-        ui->message->setText(tr("The entered address:\n") + ui->multiSendAddressEdit->text() + tr(" is invalid.\nPlease check the address and try again."));
+        ui->message->setText(tr("The entered address: %1 is invalid.\nPlease check the address and try again.").arg(ui->multiSendAddressEdit->text()));
         ui->multiSendAddressEdit->setFocus();
         return;
     }
@@ -118,7 +119,7 @@ void MultiSendDialog::on_addButton_clicked()
     if (nSumMultiSend + nMultiSendPercent > 100) {
         ui->message->setProperty("status", "error");
         ui->message->style()->polish(ui->message);
-        ui->message->setText(tr("The total amount of your MultiSend vector is over 100% of your stake reward\n"));
+        ui->message->setText(tr("The total amount of your MultiSend vector is over 100% of your stake reward"));
         ui->multiSendAddressEdit->setFocus();
         return;
     }
@@ -135,13 +136,13 @@ void MultiSendDialog::on_addButton_clicked()
     pwalletMain->vMultiSend.push_back(pMultiSend);
     ui->message->setProperty("status", "ok");
     ui->message->style()->polish(ui->message);
-    std::string strMultiSendPrint = "";
+    std::string strMultiSendPrint;
     for (int i = 0; i < (int)pwalletMain->vMultiSend.size(); i++) {
         pMultiSend = pwalletMain->vMultiSend[i];
         strMultiSendPrint += pMultiSend.first.c_str();
         strMultiSendPrint += " - ";
         strMultiSendPrint += std::to_string(pMultiSend.second);
-        strMultiSendPrint += "% \n";
+        strMultiSendPrint += "%\n";
     }
 
     if (model && model->getAddressTableModel()) {
@@ -158,11 +159,11 @@ void MultiSendDialog::on_addButton_clicked()
     if(!walletdb.WriteMultiSend(pwalletMain->vMultiSend)) {
         ui->message->setProperty("status", "error");
         ui->message->style()->polish(ui->message);
-        ui->message->setText(tr("Saved the MultiSend to memory, but failed saving properties to the database.\n"));
+        ui->message->setText(tr("Saved the MultiSend to memory, but failed saving properties to the database."));
         ui->multiSendAddressEdit->setFocus();
         return;
     }
-    ui->message->setText(tr("MultiSend Vector\n") + QString(strMultiSendPrint.c_str()));
+    ui->message->setText(tr("MultiSend Vector") + "\n" + QString(strMultiSendPrint.c_str()));
     return;
 }
 
@@ -184,9 +185,9 @@ void MultiSendDialog::on_deleteButton_clicked()
         fRemoved = false;
 
     if (fRemoved)
-        ui->message->setText(tr("Removed ") + QString(strAddress.c_str()));
+        ui->message->setText(tr("Removed %1").arg(QString(strAddress.c_str())));
     else
-        ui->message->setText(tr("Could not locate address\n"));
+        ui->message->setText(tr("Could not locate address"));
 
     updateCheckBoxes();
 
@@ -195,39 +196,41 @@ void MultiSendDialog::on_deleteButton_clicked()
 
 void MultiSendDialog::on_activateButton_clicked()
 {
-    std::string strRet = "";
+    QString strRet;
     if (pwalletMain->vMultiSend.size() < 1)
-        strRet = "Unable to activate MultiSend, check MultiSend vector\n";
+        strRet = tr("Unable to activate MultiSend, check MultiSend vector");
     else if (!(ui->multiSendStakeCheckBox->isChecked() || ui->multiSendMasternodeCheckBox->isChecked())) {
-        strRet = "Need to select to send on stake and/or masternode rewards\n";
+        strRet = tr("Need to select to send on stake and/or masternode rewards");
     } else if (CBitcoinAddress(pwalletMain->vMultiSend[0].first).IsValid()) {
         pwalletMain->fMultiSendStake = ui->multiSendStakeCheckBox->isChecked();
         pwalletMain->fMultiSendMasternodeReward = ui->multiSendMasternodeCheckBox->isChecked();
 
         CWalletDB walletdb(pwalletMain->strWalletFile);
         if (!walletdb.WriteMSettings(pwalletMain->fMultiSendStake, pwalletMain->fMultiSendMasternodeReward, pwalletMain->nLastMultiSendHeight))
-            strRet = "MultiSend activated but writing settings to DB failed";
+            strRet = tr("MultiSend activated but writing settings to DB failed");
         else
-            strRet = "MultiSend activated";
+            strRet = tr("MultiSend activated");
     } else
-        strRet = "First Address Not Valid";
+        strRet = tr("First Address Not Valid");
     ui->message->setProperty("status", "ok");
     ui->message->style()->polish(ui->message);
-    ui->message->setText(tr(strRet.c_str()));
+    ui->message->setText(strRet);
     return;
 }
 
 void MultiSendDialog::on_disableButton_clicked()
 {
-    std::string strRet = "";
+    QString strRet;
     pwalletMain->setMultiSendDisabled();
     CWalletDB walletdb(pwalletMain->strWalletFile);
+
     if (!walletdb.WriteMSettings(false, false, pwalletMain->nLastMultiSendHeight))
-        strRet = "MultiSend deactivated but writing settings to DB failed";
+        strRet = tr("MultiSend deactivated but writing settings to DB failed");
     else
-        strRet = "MultiSend deactivated";
+        strRet = tr("MultiSend deactivated");
+
     ui->message->setProperty("status", "");
     ui->message->style()->polish(ui->message);
-    ui->message->setText(tr(strRet.c_str()));
+    ui->message->setText(strRet);
     return;
 }

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -4,15 +4,15 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "multisenddialog.h"
+#include "ui_multisenddialog.h"
+
 #include "addressbookpage.h"
 #include "addresstablemodel.h"
 #include "base58.h"
 #include "init.h"
-#include "ui_multisenddialog.h"
 #include "walletmodel.h"
-#include <QLineEdit>
-#include <QMessageBox>
 
+#include <QStyle>
 
 MultiSendDialog::MultiSendDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                                     ui(new Ui::MultiSendDialog),

--- a/src/qt/multisenddialog.cpp
+++ b/src/qt/multisenddialog.cpp
@@ -16,10 +16,9 @@
 
 MultiSendDialog::MultiSendDialog(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint),
                                                     ui(new Ui::MultiSendDialog),
-                                                    model(0)
+                                                    model(nullptr)
 {
     ui->setupUi(this);
-
     updateCheckBoxes();
 }
 
@@ -58,7 +57,7 @@ void MultiSendDialog::on_addressBookButton_clicked()
         if (dlg.exec())
             setAddress(dlg.getReturnValue(), ui->multiSendAddressEdit);
 
-        //Update the label text box with the label in the addressbook
+        // Update the label text box with the label in the addressbook
         QString associatedLabel = model->getAddressTableModel()->labelForAddress(dlg.getReturnValue());
         if (!associatedLabel.isEmpty())
             ui->labelAddressLabelEdit->setText(associatedLabel);

--- a/src/qt/multisenddialog.h
+++ b/src/qt/multisenddialog.h
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef MULTISENDDIALOG_H
-#define MULTISENDDIALOG_H
+#ifndef WAGERR_QT_MULTISENDDIALOG_H
+#define WAGERR_QT_MULTISENDDIALOG_H
 
 #include <QDialog>
 
@@ -21,7 +21,7 @@ class MultiSendDialog : public QDialog
     void updateCheckBoxes();
 
 public:
-    explicit MultiSendDialog(QWidget* parent = 0);
+    explicit MultiSendDialog(QWidget* parent = nullptr);
     ~MultiSendDialog();
     void setModel(WalletModel* model);
     void setAddress(const QString& address);
@@ -39,4 +39,4 @@ private:
     WalletModel* model;
 };
 
-#endif // MULTISENDDIALOG_H
+#endif // WAGERR_QT_MULTISENDDIALOG_H


### PR DESCRIPTION
From PIVX upstream:

> Some much needed cleanup of the multisend dialog UI. Broken out into minimalistic commits for review-ability.
>
> Fixes #664 when compiling against newer versions of Qt where QStyle is no longer inherited from other includes.
>
> Also removes the dependency on boost in the file, as well as introduces proper translation functions for user-facing strings.
>
> This should hold us over until the entire multisend system/ui can be redesigned.