### PR TITLE
Replace arm building in packages.mk & remove aarch64 from trusty build

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -7,10 +7,6 @@ architectures:
 - "amd64"
 packages:
 - "curl"
-- "g++-aarch64-linux-gnu"
-- "g++-4.8-aarch64-linux-gnu"
-- "gcc-4.8-aarch64-linux-gnu"
-- "binutils-aarch64-linux-gnu"
 - "g++-arm-linux-gnueabihf"
 - "g++-4.8-arm-linux-gnueabihf"
 - "gcc-4.8-arm-linux-gnueabihf"

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -6,6 +6,9 @@ qt_packages = qrencode protobuf zlib
 
 qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
+qt_arm_linux_packages:=$(qt_x86_64_linux_packages)
+qt_armv7l_linux_packages:=$(qt_x86_64_linux_packages)
+qt_aarch64_linux_packages:=$(qt_x86_64_linux_packages)
 
 qt_darwin_packages=qt
 qt_mingw32_packages=qt


### PR DESCRIPTION
Replace arm building in packages.mk as a start to getting GUI wallets building in arm32/64 & remove aarch64 from trusty linux build (will merge back on the update to xenial).