### PR TITLE
Qt: Fix betting page heading labels

### DIFF
--- a/src/qt/forms/placebetdialog.ui
+++ b/src/qt/forms/placebetdialog.ui
@@ -287,7 +287,7 @@
                      <string notr="true">font-weight:bold;</string>
                     </property>
                     <property name="text">
-                     <string>Home (W)</string>
+                     <string>Home</string>
                     </property>
                    </widget>
                   </item>
@@ -320,7 +320,7 @@
                      <string notr="true">font-weight:bold;</string>
                     </property>
                     <property name="text">
-                     <string>Away (W)</string>
+                     <string>Away</string>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
Erroneous '(W)' was showing in the headings.