### PR TITLE
Add warning in RPC Console about divulging private keys

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -639,7 +639,9 @@ void RPCConsole::clear()
     message(CMD_REPLY, (tr("Welcome to the Wagerr RPC console.") + "<br>" +
                            tr("Use up and down arrows to navigate history, and <b>Ctrl-L</b> to clear screen.") + "<br>" +
                            tr("Type <b>help</b> for an overview of available commands.") + "<br><br>" +
-                           tr("WARNING: Placing bets via RPC and the debug console can result in loss of funds and invalid bets. We recommend using the betting GUI only to place bets. All other bets are done at your own risk.")),
+                           tr("WARNING(S):") + "<br>" +
+                           tr("Placing bets via RPC and the debug console can result in loss of funds and invalid bets. We recommend using the betting GUI only to place bets. All other bets are done at your own risk.") + "<br><br>" +
+                           tr("Please note the <b>dumpwallet</b>, <b>dumpprivkey</b>, and <b>getzwgrseed</b> RPC command outputs do not need to be shared with anyone other than yourself. Even if someone is reputable and claims to be helping you, these commands are not needed for debugging.")),
         true);
 }
 


### PR DESCRIPTION
Due to reports from the community around bad actors attempting to have users send their wallet keys, adding some warnings in the RPC Console.