### PR TITLE
When listing events only look back the past 16 days worth of blocks

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -65,6 +65,8 @@ UniValue listevents(const UniValue& params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("listevents", "") + HelpExampleRpc("listevents", ""));
 
+    int nCurrentHeight = chainActive.Height();
+
     UniValue ret(UniValue::VARR);
     
     // Set the Oracle wallet address. 
@@ -76,12 +78,13 @@ UniValue listevents(const UniValue& params, bool fHelp)
     // we know that that transaction has been sent from our "Core Wallet" and we
     // will process the transaction.
     std::map<uint256, uint32_t> coreWalletVouts;
-
-    // TODO We currently search the entire block chain every time we query the
-    // current events. Instead, the events up to a particular block/transaction
-    // should be read and cached when the process starts, and ideally persisted,
-    // to reduce the processing time for this command.
-    CBlockIndex* pindex = chainActive.Height() > Params().BetStartHeight() ? chainActive[Params().BetStartHeight()] : NULL;
+    
+    // Similar to bet payouts only look back in the chain 16 days for any
+    // events to list.
+    //
+    // TODO: Once an event is read then cache and persist the event data to
+    // reduce processing time.
+    CBlockIndex* pindex = chainActive[nCurrentHeight - Params().BetBlocksIndexTimespan()];
 
     while (pindex) {
 


### PR DESCRIPTION
This should significantly improve the `listevents` command as it no longer scans the whole blockchain for events. This is the same logic used to payout bets.

Tested with the below code and `listevents` duration went from approximately **50s** to **6s** on my machine.

```c++
UniValue listevents(const UniValue& params, bool fHelp)
{    
    auto start = std::chrono::high_resolution_clock::now();

    ...

    auto finish = std::chrono::high_resolution_clock::now();
    std::chrono::duration<double> elapsed = finish - start;
    std::cout << "Elapsed time: " << elapsed.count() << " s\n";

    ...
}
```