### PR TITLE
[FIX] Update handling of spreads and totals

### DIFF
--- a/src/betting/bet.cpp
+++ b/src/betting/bet.cpp
@@ -1907,7 +1907,6 @@ std::vector<CBetOut> GetBetPayouts(int height)
                             LogPrintf("PSE EVENT OP CODE - %s \n", opCode.c_str());
 
                             UpdateSpreads = true;
-                            spreadsFound  = true;
 
                             // If the home team is the favourite.
                             if (HomeFavorite){
@@ -1961,7 +1960,6 @@ std::vector<CBetOut> GetBetPayouts(int height)
                             LogPrintf("PTE EVENT OP CODE - %s \n", opCode.c_str());
 
                             UpdateTotals = true;
-                            totalsFound  = true;
 
                             // Find totals outcome (result).
                             if (pte.nPoints == nTotalsPoints) {
@@ -2106,6 +2104,8 @@ std::vector<CBetOut> GetBetPayouts(int height)
             // If we need to update the spreads odds using temp values.
             if (UpdateSpreads) {
                 UpdateSpreads = false;
+                spreadsFound = true;
+
                 //set the payout odds (using the temp odds)
                 nSpreadsOdds = nTempSpreadsOdds;
                 //clear the winner vector (used to determine which bets to payout).
@@ -2131,6 +2131,8 @@ std::vector<CBetOut> GetBetPayouts(int height)
             // If we need to update the totals odds using the temp values.
             if (UpdateTotals) {
                 UpdateTotals = false;
+                totalsFound = true;
+
                 nTotalsOdds  = nTempTotalsOdds;
                 vTotalsResult.clear();
 


### PR DESCRIPTION
An edge is possible where the first spreads or totals odds are published in a block that has a bet on that event. Due to faulty tracking of odds, betting payouts will look at an empty vector.