### PR TITLE
Solving a dead end inconsistency over the masternode activation process.

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -759,7 +759,10 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled, bool fChec
     LogPrint("masternode", "CMasternodePing::CheckAndUpdate - New Ping - %s - %s - %lli\n", GetHash().ToString(), blockHash.ToString(), sigTime);
 
     if (isMasternodeFound && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
-        if (fRequireEnabled && !pmn->IsEnabled()) return false;
+        // Update ping only if the masternode is active/enabled
+        if (fRequireEnabled && (!pmn->IsEnabled() && !pmn->IsPreEnabled())) {
+            return false;
+        }
 
         // LogPrint("masternode","mnping - Found corresponding mn for vin: %s\n", vin.ToString());
         // update only if there is no known ping for this masternode or

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -262,6 +262,11 @@ public:
         return activeState == MASTERNODE_ENABLED;
     }
 
+    bool IsPreEnabled()
+    {
+        return activeState == MASTERNODE_PRE_ENABLED;
+    }
+
     int GetMasternodeInputAge()
     {
         if (chainActive.Tip() == NULL) return 0;


### PR DESCRIPTION
"A valid masternode is created, mn start message is broadcasted and the entire network receives it. Peers move the masternode status to pre_enable (active) and are waiting for a mn ping update to fulfill the min ping time requirement after it activation to move to enable.

Issue:

As the mnping update message work flow is not performing any action until the mastergit push --set-upstream origin 2020_mn_ping_updatenode is in enable status (masternode.cpp, line 707), the masternode ping is never updated, there by the masternode will never be moved to enable status."