### PR TITLE
Reduce memory footprint from zerocoin supply map

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -186,7 +186,7 @@ public:
     uint32_t nSequenceId;
 
     //! zerocoin specific fields
-    std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
+    std::map<libzerocoin::CoinDenomination, int16_t> mapZerocoinSupply;
     std::vector<libzerocoin::CoinDenomination> vMintDenominationsInBlock;
 
     void SetNull()
@@ -299,7 +299,7 @@ public:
      * @param denom
      * @return
      */
-    int64_t GetZcMints(libzerocoin::CoinDenomination denom) const
+    int16_t GetZcMints(libzerocoin::CoinDenomination denom) const
     {
         return mapZerocoinSupply.at(denom);
     }

--- a/src/denomination_functions.cpp
+++ b/src/denomination_functions.cpp
@@ -145,7 +145,7 @@ std::vector<CMintMeta> getSpends(
 // -------------------------------------------------------------------------------------------------------
 void listSpends(const std::vector<CZerocoinMint>& vSelectedMints)
 {
-    std::map<libzerocoin::CoinDenomination, int64_t> mapZerocoinSupply;
+    std::map<libzerocoin::CoinDenomination, int16_t> mapZerocoinSupply;
     for (auto& denom : libzerocoin::zerocoinDenomList)
         mapZerocoinSupply.insert(std::make_pair(denom, 0));
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -146,7 +146,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
 
     UniValue zwgrObj(UniValue::VOBJ);
     for (auto denom : libzerocoin::zerocoinDenomList) {
-        zwgrObj.push_back(Pair(std::to_string(denom), ValueFromAmount(blockindex->mapZerocoinSupply.at(denom) * (denom*COIN))));
+        zwgrObj.push_back(Pair(std::to_string(denom), ValueFromAmount((denom*COIN) * blockindex->mapZerocoinSupply.at(denom))));
     }
     zwgrObj.push_back(Pair("total", ValueFromAmount(blockindex->GetZerocoinSupply())));
     result.push_back(Pair("zWGRsupply", zwgrObj));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -145,7 +145,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("moneysupply",ValueFromAmount(chainActive.Tip()->nMoneySupply)));
     UniValue zwgrObj(UniValue::VOBJ);
     for (auto denom : libzerocoin::zerocoinDenomList) {
-        zwgrObj.push_back(Pair(std::to_string(denom), ValueFromAmount(chainActive.Tip()->mapZerocoinSupply.at(denom) * (denom*COIN))));
+        zwgrObj.push_back(Pair(std::to_string(denom), ValueFromAmount((denom*COIN) * chainActive.Tip()->mapZerocoinSupply.at(denom))));
     }
     zwgrObj.push_back(Pair("total", ValueFromAmount(chainActive.Tip()->GetZerocoinSupply())));
     obj.push_back(Pair("zWGRsupply", zwgrObj));


### PR DESCRIPTION
Zerocoin supply data were stored in the blockchain as 64 bit ints while 16 bit ints are enough.