### PR TITLE
Update boost to download from jfrog mirror as bintray is now offline

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,6 @@
 package=boost
 $(package)_version=1_64_0
-$(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
+ $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
 


### PR DESCRIPTION
Bintray archive is now offline, need to download boost from jfrog archive